### PR TITLE
Allow BrowserSync port override in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,9 +110,10 @@ gulp.task('dev', gulp.series('html', 'sass', 'js'));
 gulp.task('serve', () => {
   return browserSync.init({
     server: {
-      baseDir: [ 'dist' ],
-      port: 3000
+      baseDir: [ 'dist' ]
+      // port: 3000 <--- moved port from here...
     },
+    port: 3000, // <--- ...to here
     open: false
   });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,9 +111,8 @@ gulp.task('serve', () => {
   return browserSync.init({
     server: {
       baseDir: [ 'dist' ]
-      // port: 3000 <--- moved port from here...
     },
-    port: 3000, // <--- ...to here
+    port: 3000,
     open: false
   });
 });


### PR DESCRIPTION
I moved the port outside of the server declaration onto its own line, which will let you override the BrowserSync default and use another option like `localhost:8080` (or 4000, 3200, etc.).

The setup works as it is, but with the current settings BrowserSync will still use `localhost:3000` even if you've declared a different port. I'm not sure if that's universal, but it's what I ran into on my machine - I'm running High Sierra, Gulp 4.0, and Node 8.11.4.

<img width="345" alt="Screen Shot 2019-04-26 at 1 18 55 PM" src="https://user-images.githubusercontent.com/5799346/56829293-56c5ca80-6831-11e9-999a-ce4f05762b92.png">

