### PR TITLE
Stop specifying browsers through autoprefixer options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Environment (please complete the following information):**
 - Node Version: [e.g. 10]
 - Gulp Version: [e.g. 4.0.2]
-- Gulp Starter Kit Version: [e.g. 0.10.4-beta]
+- Gulp Starter Kit Version: [e.g. 0.10.5-beta]
 - Version of any other affected dependency: [e.g. browser-sync@2.26.5]
 
 **OS (please complete the following information):**

--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ Here's a list of the currently supported CSS preprocessors and the corresponding
 - Less (`src/assets/less`)
 - Stylus (`src/assets/stylus`)
 
+### How can I specify for which browsers CSS code should be autoprefixed?
+The recommended way of specifying which browsers should be targeted by the CSS autoprefixer is to add a `browserslist` key to `package.json`:
+
+```json
+{
+  "browserslist": [
+    "last 3 versions",
+    "> 0.5%"
+  ]
+}
+```
+
+You can find [more information on that topic](https://github.com/postcss/autoprefixer#browsers) in the README file of the employed [PostCSS plugin](https://github.com/postcss/autoprefixer).
+
 ### What types of images are supported?
 The following types of images are currently supported:
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@
  * @author JR Cologne <kontakt@jr-cologne.de>
  * @copyright 2019 JR Cologne
  * @license https://github.com/jr-cologne/gulp-starter-kit/blob/master/LICENSE MIT
- * @version v0.10.4-beta
+ * @version v0.10.5-beta
  * @link https://github.com/jr-cologne/gulp-starter-kit GitHub Repository
  * @link https://www.npmjs.com/package/@jr-cologne/create-gulp-starter-kit npm package site
  *

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,10 +41,6 @@ const gulp                      = require('gulp'),
       node_modules_folder       = './node_modules/',
       dist_node_modules_folder  = dist_folder + 'node_modules/',
 
-      autoprefixer_options      = {
-        browsers: [ 'last 3 versions', '> 0.5%' ]
-      },
-
       node_dependencies         = Object.keys(require('./package.json').dependencies || {});
 
 gulp.task('clear', () => del([ dist_folder ]));
@@ -77,7 +73,7 @@ gulp.task('sass', () => {
     .pipe(sourcemaps.init())
       .pipe(plumber())
       .pipe(sass())
-      .pipe(autoprefixer(autoprefixer_options))
+      .pipe(autoprefixer())
       .pipe(minifyCss())
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest(dist_assets_folder + 'css'))
@@ -89,7 +85,7 @@ gulp.task('less', () => {
     .pipe(sourcemaps.init())
       .pipe(plumber())
       .pipe(less())
-      .pipe(autoprefixer(autoprefixer_options))
+      .pipe(autoprefixer())
       .pipe(minifyCss())
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest(dist_assets_folder + 'css'))
@@ -101,7 +97,7 @@ gulp.task('stylus', () => {
     .pipe(sourcemaps.init())
       .pipe(plumber())
       .pipe(stylus())
-      .pipe(autoprefixer(autoprefixer_options))
+      .pipe(autoprefixer())
       .pipe(minifyCss())
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest(dist_assets_folder + 'css'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jr-cologne/create-gulp-starter-kit",
-  "version": "0.10.4-beta",
+  "version": "0.10.5-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jr-cologne/create-gulp-starter-kit",
-  "version": "0.10.4-beta",
+  "version": "0.10.5-beta",
   "description": "A simple Gulp 4 Starter Kit for modern web development.",
   "keywords": [
     "gulp",


### PR DESCRIPTION
It is not recommended to specify browsers, which should be targeted for autoprefixing CSS, inside the autoprefixer options.
Actually, we are completely moving away from overwriting `browserslist`'s defaults since they are probably a better fit for most people instead of the custom setting `last 3 versions, > 0.5%`.

closes #28 