### PR TITLE
Updated minimum supported version of node

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here is a list of the current features:
 ## Requirements
 This should be installed on your computer in order to get up and running:
 
-- [Node.js](https://nodejs.org/en/)
+- [Node.js](https://nodejs.org/en/) (Required node version is >= 8.0)
 - [Gulp 4](https://gulpjs.com/)
 
 ## Dependencies

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
   "dependencies": {
     "axios": "^0.19.0",
     "fs-extra": "^8.1.0"
+  },
+  "engines": {
+    "node": ">=8"
   }
 }


### PR DESCRIPTION
I have checked the required node versions for each of the dependencies specified in the README.
Some packages have not mentioned any specific versions, though, so I have marked them as `NA`
Here's the list:
* @babel/core: >=6.9.0
* @babel/preset-env: NA
* browser-sync: >= 6.0.0
* del: >=8
* gulp: >= 0.10
* gulp-autoprefixer: >=8
* gulp-babel: >=6
* gulp-concat: >= 0.10
* gulp-clean-css: NA
* gulp-sass: >=6
* gulp-plumber: >=0.10
* gulp-sourcemaps: >= 0.10
* gulp-uglify: NA
* gulp-imagemin: >=8
* webpack-stream: >= 6.11.5
* gulp-pug: >= 4.0.0
* gulp-less: >=0.10.0
* gulp-stylus: >= 4.2.0